### PR TITLE
Explicitly use python3 in the shebang line

### DIFF
--- a/mipi-dbi-cmd
+++ b/mipi-dbi-cmd
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # SPDX-License-Identifier: CC0-1.0


### PR DESCRIPTION
This reduces confusion about wether the script should use a version 2.x or a version 3.x Python interpreter.

My motivation for this is that we want to upstream our [local Yocto recipe](https://github.com/linux-automation/meta-lxatac/tree/scarthgap/meta-lxatac-software/recipes-graphics/panel-mipi-dbi) for `panel-mipi-dbi` to [meta-openembedded](https://github.com/openembedded/meta-openembedded) and getting this PR merged would allow us to drop a patch that we currently apply in the recipe.